### PR TITLE
Fix possible typo in README.md sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Usage:
 ```mungefsctl --operations "read" --corrupt_data```
 
 ## Corrupting the reporting of filesize:
-```mungefsctl --operations "getattr" --corrupt_data```
+```mungefsctl --operations "getattr" --corrupt_size```
 
 ## Resetting the operations:
 ```


### PR DESCRIPTION
Changed `--corrupt_data` option in "Corrupting the reporting of filesize" sample to `--corrupt_size` as the other way does not appear to work.