### PR TITLE
Do not assume libc++ (main)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,7 @@ if (NOT CPACK_PACKAGING_INSTALL_PREFIX)
   message(STATUS "Setting unspecified CPACK_PACKAGING_INSTALL_PREFIX to '${CPACK_PACKAGING_INSTALL_PREFIX}'. This is the correct setting for normal builds.")
 endif()
 
-add_compile_options(-nostdinc++ -Wall -Werror)
-include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1)
+add_compile_options(-Wall -Werror)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
~~DO NOT MERGE YET - Still need to submit PR to externals repo so that these flags can be passed from there~~
Turns out, no changes are needed to the externals repository as it already passes the appropriate flags.

This PR enables mungefs to be built against libstdc++